### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dotenv": "^8.2.0",
     "passport": "^0.4.1",
     "passport-github": "^1.1.0",
-    "body-parser": "^1.19.0"
+    "body-parser": "^1.19.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.4"

--- a/src/server/routes/tools.js
+++ b/src/server/routes/tools.js
@@ -1,6 +1,16 @@
 const express = require('express');
 const router = express.Router();
 const toolController = require('../controllers/toolController');
+const rateLimit = require('express-rate-limit');
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
+// Apply rate limiter to all routes
+router.use(limiter);
 
 // Route to create a new tool
 router.post('/', toolController.createTool);


### PR DESCRIPTION
Potential fix for [https://github.com/Julieisbaka/tool-gallery/security/code-scanning/5](https://github.com/Julieisbaka/tool-gallery/security/code-scanning/5)

To fix the problem, we need to introduce rate limiting to the route handlers in the `src/server/routes/tools.js` file. The best way to do this is by using the `express-rate-limit` middleware, which allows us to set a maximum number of requests that can be made to the server within a specified time window. This will help prevent abuse and protect the server from being overwhelmed by too many requests.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/server/routes/tools.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum 100 requests per 15 minutes).
4. Apply the rate limiter to the route handlers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
